### PR TITLE
Make DeployKey.LastUsed nullable

### DIFF
--- a/Octokit/Models/Response/DeployKey.cs
+++ b/Octokit/Models/Response/DeployKey.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public DeployKey() { }
 
-        public DeployKey(int id, string key, string url, string title, bool verified, DateTimeOffset createdAt, bool readOnly, string addedBy, DateTimeOffset lastUsed)
+        public DeployKey(int id, string key, string url, string title, bool verified, DateTimeOffset createdAt, bool readOnly, string addedBy, DateTimeOffset? lastUsed)
         {
             Id = id;
             Key = key;
@@ -30,7 +30,7 @@ namespace Octokit
         public DateTimeOffset CreatedAt { get; protected set; }
         public bool ReadOnly { get; protected set; }
         public string AddedBy { get; protected set; }
-        public DateTimeOffset LastUsed { get; protected set; }
+        public DateTimeOffset? LastUsed { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -4,7 +4,7 @@
     <Description>An async-based GitHub API client library for .NET and .NET Core</Description>
     <AssemblyTitle>Octokit</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <Version>1.0.12</Version>
+    <Version>1.0.13</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Octokit</AssemblyName>
     <PackageId>Apiiro.Octokit</PackageId>


### PR DESCRIPTION
Continuing https://github.com/apiiro/octokit.net/pull/11

Looking at the schema, I missed the part where `LastUsed` could be null: https://docs.github.com/en/rest/deploy-keys?apiVersion=2022-11-28#list-deploy-keys