### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To push to apiiro nuget package:
 ```bash
 cd Octokit
 dotnet pack --configuration Release
-dotnet nuget push bin/Release/Apiiro.Octokit.*.nupkg --source "github" --skip-duplicate --no-symbols true
+dotnet nuget push bin/Release/Apiiro.Octokit.*.nupkg --source "github" --skip-duplicate --no-symbols
 ```
 
 Octokit is a client library targeting .NET Framework 4.5+ and .NET Standard 1+


### PR DESCRIPTION
The new version of `dotnet nuget` don't require to pass `true` anymore when using `no-symbols` flag