### PR TITLE
Add initial support for etags

### DIFF
--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -415,7 +415,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.Repositories(login), options);
+            return ApiConnection.GetAll<Repository>(ApiUrls.Repositories(login), options, false);
         }
 
         /// <summary>
@@ -451,7 +451,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.OrganizationRepositories(organization), options);
+            return ApiConnection.GetAll<Repository>(ApiUrls.OrganizationRepositories(organization), options, true);
         }
 
         /// <summary>

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -141,7 +141,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options, bool enableETags = true)
+        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options, bool enableETags = false)
         {
             return GetAll<T>(uri, null, null, options, enableETags);
         }
@@ -202,7 +202,7 @@ namespace Octokit
             return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts).ConfigureAwait(false), uri);
         }
 
-        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options, bool enableETags = true)
+        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options, bool enableETags = false)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -141,9 +141,9 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options)
+        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options, bool enableETags = true)
         {
-            return GetAll<T>(uri, null, null, options);
+            return GetAll<T>(uri, null, null, options, enableETags);
         }
 
         /// <summary>
@@ -202,14 +202,14 @@ namespace Octokit
             return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts).ConfigureAwait(false), uri);
         }
 
-        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options)
+        public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options, bool enableETags = true)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(options, nameof(options));
 
             parameters = Pagination.Setup(parameters, options);
 
-            return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts, options).ConfigureAwait(false), uri);
+            return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts, options, enableETags).ConfigureAwait(false), uri);
         }
 
         /// <summary>
@@ -613,13 +613,14 @@ namespace Octokit
             Uri uri,
             IDictionary<string, string> parameters,
             string accepts,
-            ApiOptions options)
+            ApiOptions options,
+            bool enableETags)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
             var connection = Connection;
 
-            var response = await connection.Get<List<TU>>(uri, parameters, accepts).ConfigureAwait(false);
+            var response = await connection.Get<List<TU>>(uri, parameters, accepts, enableETags).ConfigureAwait(false);
             return new ReadOnlyPagedCollection<TU>(
                 response,
                 nextPageUri =>

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -13,6 +13,7 @@ namespace Octokit
             IList<string> oauthScopes,
             IList<string> acceptedOauthScopes,
             string etag,
+            string lastModified,
             RateLimit rateLimit,
             TimeSpan serverTimeDifference = default)
         {
@@ -24,6 +25,7 @@ namespace Octokit
             OauthScopes = new ReadOnlyCollection<string>(oauthScopes);
             AcceptedOauthScopes = new ReadOnlyCollection<string>(acceptedOauthScopes);
             Etag = etag;
+            LastModified = lastModified;
             RateLimit = rateLimit;
             ServerTimeDifference = serverTimeDifference;
         }
@@ -42,6 +44,8 @@ namespace Octokit
         /// Etag
         /// </summary>
         public string Etag { get; private set; }
+
+        public string LastModified { get; private set; }
 
         /// <summary>
         /// Links to things like next/previous pages
@@ -74,6 +78,7 @@ namespace Octokit
                                OauthScopes.Clone(),
                                AcceptedOauthScopes.Clone(),
                                Etag != null ? new string(Etag.ToCharArray()) : null,
+                               LastModified != null ? new string(LastModified.ToCharArray()) : null,
                                RateLimit != null ? RateLimit.Clone() : null,
                                ServerTimeDifference);
         }

--- a/Octokit/Http/ApiInfoParser.cs
+++ b/Octokit/Http/ApiInfoParser.cs
@@ -37,6 +37,7 @@ namespace Octokit.Internal
             var oauthScopes = new List<string>();
             var acceptedOauthScopes = new List<string>();
             string etag = null;
+            string lastModified = null;
 
             var acceptedOauthScopesKey = LookupHeader(responseHeaders, "X-Accepted-OAuth-Scopes");
             if (Exists(acceptedOauthScopesKey))
@@ -58,6 +59,12 @@ namespace Octokit.Internal
             if (Exists(etagKey))
             {
                 etag = etagKey.Value;
+            }
+            
+            var lastModifiedKey = LookupHeader(responseHeaders, "Last-Modified");
+            if (Exists(lastModifiedKey))
+            {
+                lastModified = lastModifiedKey.Value;
             }
 
             var linkKey = LookupHeader(responseHeaders, "Link");
@@ -85,7 +92,7 @@ namespace Octokit.Internal
                 serverTimeSkew = serverTime - receivedTime;
             }
 
-            return new ApiInfo(httpLinks, oauthScopes, acceptedOauthScopes, etag, new RateLimit(responseHeaders), serverTimeSkew);
+            return new ApiInfo(httpLinks, oauthScopes, acceptedOauthScopes, etag, lastModified, new RateLimit(responseHeaders), serverTimeSkew);
         }
     }
 }

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -196,7 +196,7 @@ namespace Octokit
         }
         private ApiInfo _lastApiInfo;
 
-        public Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts, bool enableETags = true)
+        public Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts, bool enableETags = false)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
@@ -412,7 +412,7 @@ namespace Octokit
             CancellationToken cancellationToken,
             string twoFactorAuthenticationCode = null,
             Uri baseAddress = null,
-            bool enableETags = true)
+            bool enableETags = false)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options);
+        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options, bool enableETags = true);
 
         /// <summary>
         /// Gets all API resources in the list at the specified URI.
@@ -142,7 +142,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options);
+        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options, bool enableETags = true);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options, bool enableETags = true);
+        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options, bool enableETags = false);
 
         /// <summary>
         /// Gets all API resources in the list at the specified URI.
@@ -142,7 +142,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options, bool enableETags = true);
+        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options, bool enableETags = false);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -39,7 +39,7 @@ namespace Octokit
         /// <param name="accepts">Specifies accepted response media types.</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts, bool enableETags = true);
+        Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts, bool enableETags = false);
 
         /// <summary>
         /// Performs an asynchronous HTTP GET request.

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -39,7 +39,7 @@ namespace Octokit
         /// <param name="accepts">Specifies accepted response media types.</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts);
+        Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts, bool enableETags = true);
 
         /// <summary>
         /// Performs an asynchronous HTTP GET request.

--- a/Octokit/Http/IRequest.cs
+++ b/Octokit/Http/IRequest.cs
@@ -14,5 +14,7 @@ namespace Octokit.Internal
         Uri Endpoint { get; }
         TimeSpan Timeout { get; }
         string ContentType { get; }
+        
+        bool EnableETags { get; }
     }
 }

--- a/Octokit/Http/Request.cs
+++ b/Octokit/Http/Request.cs
@@ -12,6 +12,7 @@ namespace Octokit.Internal
             Headers = new Dictionary<string, string>();
             Parameters = new Dictionary<string, string>();
             Timeout = TimeSpan.FromSeconds(100);
+            EnableETags = true;
         }
 
         public object Body { get; set; }
@@ -22,5 +23,6 @@ namespace Octokit.Internal
         public Uri Endpoint { get; set; }
         public TimeSpan Timeout { get; set; }
         public string ContentType { get; set; }
+        public bool EnableETags { get; set; }
     }
 }


### PR DESCRIPTION
* Adds functions in the constructor to get and set the cache
* Adds specific override for getting repositories to not use etags

Notice that this PR is merged into `talfin/conditional-requests` to be used as a middle step.
Splitting this will help with reviewing, and the other branch will be merged into main once we're done.

I know you wanted an interface, but for now lets use the cache functions and I'll review this decision before we finish this feature.

Closes LIM-12356
Closes LIM-12357