### PR TITLE
Add HttpClientAdapter constructor accepting external HttpClient

### DIFF
--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -30,6 +30,17 @@ namespace Octokit.Internal
             Ensure.ArgumentNotNull(getHandler, nameof(getHandler));
 
             _http = new HttpClient(new RedirectHandler { InnerHandler = getHandler() });
+        }
+
+        /// <summary>
+        /// Creates an adapter using an externally provided <see cref="HttpClient"/>.
+        /// </summary>
+        /// <param name="httpClient">A pre-configured <see cref="HttpClient"/> instance</param>
+        public HttpClientAdapter(HttpClient httpClient)
+        {
+            Ensure.ArgumentNotNull(httpClient, nameof(httpClient));
+
+            _http = httpClient;
         }
 
         /// <summary>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>An async-based GitHub API client library for .NET and .NET Core</Description>
     <AssemblyTitle>Octokit</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <Version>1.0.26</Version>
+    <Version>1.0.27</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Octokit</AssemblyName>
     <PackageId>Apiiro.Octokit</PackageId>


### PR DESCRIPTION
Closes LIM-38300

## Summary

- Add a new `HttpClientAdapter` constructor that accepts a pre-configured `HttpClient` instance, enabling callers to inject an `HttpClient` with HTTP/2 protocol support
- Bump package version to `1.0.27`


Made with [Cursor](https://cursor.com)