### PR TITLE
Guard against null audit-log response in AuditOrganizationsClient

### DIFF
--- a/Octokit.Tests/Clients/AuditOrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuditOrganizationsClientTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class AuditOrganizationsClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new AuditOrganizationsClient(null));
+            }
+        }
+
+        public class TheAuditLogQueryMethods
+        {
+            private static AuditOrganizationsClient CreateClientReturningNullResponse()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                connection.Get<List<AuditLogEvent>>(Arg.Any<Uri>(), Arg.Any<IDictionary<string, string>>())
+                    .Returns(Task.FromResult<List<AuditLogEvent>>(null));
+                return new AuditOrganizationsClient(connection);
+            }
+
+            [Fact]
+            public async Task GetRepositoryVisibilityChangeLastEventReturnsNullWhenResponseIsNull()
+            {
+                var client = CreateClientReturningNullResponse();
+
+                var result = await client.GetRepositoryVisibilityChangeLastEvent("org", new AuditLogPhraseOptions { Repository = "repo" });
+
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public async Task GetRepositoryCreatedLastEventReturnsNullWhenResponseIsNull()
+            {
+                var client = CreateClientReturningNullResponse();
+
+                var result = await client.GetRepositoryCreatedLastEvent("org", new AuditLogPhraseOptions { Repository = "repo" });
+
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public async Task GetUserLastActivityForRepositoryDateReturnsNullWhenResponseIsNull()
+            {
+                var client = CreateClientReturningNullResponse();
+
+                var result = await client.GetUserLastActivityForRepositoryDate("org", new AuditLogPhraseOptions { Repository = "repo", User = "user" });
+
+                Assert.Null(result);
+            }
+        }
+    }
+}

--- a/Octokit/Clients/AuditOrganizationsClient.cs
+++ b/Octokit/Clients/AuditOrganizationsClient.cs
@@ -56,7 +56,7 @@ namespace Octokit
             var phrase = auditLogPhraseOptions.BuildPhrase(organization, "repo.access");
             var auditLogs = await ApiConnection.Get<List<AuditLogEvent>>(ApiUrls.AuditLog(organization, phrase), parameters);
 
-            if (!auditLogs.Any())
+            if (auditLogs is null || !auditLogs.Any())
             {
                 return null;
             }
@@ -97,7 +97,7 @@ namespace Octokit
             var phrase = auditLogPhraseOptions.BuildPhrase(organization, "repo.create");
             var auditLogs = await ApiConnection.Get<List<AuditLogEvent>>(ApiUrls.AuditLog(organization, phrase), parameters);
 
-            if (!auditLogs.Any())
+            if (auditLogs is null || !auditLogs.Any())
             {
                 return null;
             }
@@ -120,7 +120,7 @@ namespace Octokit
             var phrase = auditLogPhraseOptions?.BuildPhrase(organization);
             var auditLogs = await ApiConnection.Get<List<AuditLogEvent>>(ApiUrls.AuditLog(organization, phrase), parameters);
 
-            if (!auditLogs.Any())
+            if (auditLogs is null || !auditLogs.Any())
             {
                 return null;
             }

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -4,7 +4,7 @@
     <Description>An async-based GitHub API client library for .NET and .NET Core</Description>
     <AssemblyTitle>Octokit</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <Version>1.0.27</Version>
+    <Version>1.0.28</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Octokit</AssemblyName>
     <PackageId>Apiiro.Octokit</PackageId>


### PR DESCRIPTION
## Problem

`AuditOrganizationsClient`'s audit-log query methods call `ApiConnection.Get<List<AuditLogEvent>>(...)` and immediately evaluate `!auditLogs.Any()`. For some audit-log responses the payload deserializes to `null` rather than an empty list, so `.Any()` throws `ArgumentNullException` (`Value cannot be null. (Parameter 'source')`) instead of reporting "no matching event".

This affects all three methods that follow the pattern:
- `GetRepositoryVisibilityChangeLastEvent`
- `GetRepositoryCreatedLastEvent`
- `GetLastActivityDateImpl` (used by `GetLastActivityDate` and `GetUserLastActivityForRepositoryDate`)

## Fix

Treat a `null` response the same as an empty one — return `null` (no event). Added a null guard at each site, plus regression tests, and bumped the package version to `1.0.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)